### PR TITLE
fix fading sprites

### DIFF
--- a/mode-lambda/backend/gl/ngl.fragment.glsl
+++ b/mode-lambda/backend/gl/ngl.fragment.glsl
@@ -47,14 +47,20 @@ void main(void)
 
   vec4 fin_Color;
 
+  // Color.rgb is the #:r, #:b, #:g passed to the (sprite) call
+  // PixelColor is from the sprite, is premultiplied alpha
+
   fin_Color.a = PixelColor.a * Color.a;
 
-  // Convert Color.rgb to premultiplied alpha using Pixel's alpha
+  // add Color.rgb to sprite color, but only where the sprite is opaque
   fin_Color.rgb = PixelColor.rgb + Color.rgb * PixelColor.a;
 
   // Adding could have pushed rgb over alpha, cap it to maintain
   // premultiplied alpha
-  fin_Color.rgb = min(fin_Color.rgb, fin_Color.a);
+  fin_Color.rgb = min(fin_Color.rgb, PixelColor.a);
+
+  // scale final color by #:a passed to (sprite)
+  fin_Color.rgb *= Color.a;
 
   vec4 blank_Color = vec4(0.0,0.0,0.0,0.0);
   


### PR DESCRIPTION
I finally figured out why the fading sprites didn't look right.  After combining the sprite color PixelColor.rgb and the Color.rgb from the (sprite) call, it needs to be scaled by the #:a argument to (sprite).

I was wrong before in the comment about making Color.rgb into premultiplied alpha.  It's not being combined in the normal way, it's tinting the sprite pixel color.  That also answers why after adding it we have to cap it to PixelColor.a to maintain the premultiplied alpha invariant.  Hope that makes sense.