### PR TITLE
add optional #:r/g/b to specify background color

### DIFF
--- a/mode-lambda/backend/gl.rkt
+++ b/mode-lambda/backend/gl.rkt
@@ -223,7 +223,7 @@
           (make-delayed-fbo 1)))
       (define front? #f)
 
-      (λ (update-scale? the-scale-info LayerTargetsTex)
+      (λ (update-scale? the-scale-info LayerTargetsTex r g b)
         (when update-scale?
           (for ([combine-dfbo (in-list combine-dfbos)])
             (initialize-dfbo! combine-dfbo the-scale-info)))
@@ -239,6 +239,10 @@
              [with-texture-array (GL_TEXTURE1 LayerTargetsTex)]
              [with-program (combine-program)])
           (set-uniform-scale-info! combine-program the-scale-info)
+          (glUniform3f (glGetUniformLocation combine-program "BackgroundColor")
+                       (fl/ (fx->fl r) 255.0)
+                       (fl/ (fx->fl g) 255.0)
+                       (fl/ (fx->fl b) 255.0))
           (glClearColor 0.0 0.0 0.0 0.0)
           (glClear GL_COLOR_BUFFER_BIT)
           (set-viewport/fpair! (scale-info-texture the-scale-info))
@@ -286,7 +290,7 @@
   (define LogicalSize (pair->fpair width height))
 
   (define the-scale-info #f)
-  (λ (screen-width.fx screen-height.fx layer-config static-st dynamic-st)
+  (λ (screen-width.fx screen-height.fx layer-config static-st dynamic-st r g b)
     (define screen-width (fx->fl screen-width.fx))
     (define screen-height (fx->fl screen-height.fx))
     ;; If this were 8/7, then we'd have the same PAR as the NES on a
@@ -336,7 +340,7 @@
     (define LayerTargetsTex
       (render-layers! update-scale? the-scale-info static-st dynamic-st))
     (define combine-tex
-      (combine-layers! update-scale? the-scale-info LayerTargetsTex))
+      (combine-layers! update-scale? the-scale-info LayerTargetsTex r g b))
     (when shot!
       (local-require ffi/vector
                      racket/file)

--- a/mode-lambda/backend/gl/combine.fragment.glsl
+++ b/mode-lambda/backend/gl/combine.fragment.glsl
@@ -6,6 +6,7 @@ uniform float XScale;
 uniform float YScale;
 uniform vec2 LogicalSize;
 uniform vec2 TextureSize;
+uniform vec3 BackgroundColor;
 
 in vec2 iTexCoord;
 
@@ -40,7 +41,7 @@ void main() {
   float ax = iTexCoord.x * width;
   float ay = height - iTexCoord.y * height;
 
-  vec4 fin_Color = vec4(0.0, 0.0, 0.0, 1.0);
+  vec4 fin_Color = vec4(BackgroundColor, 1.0);
 @in[compiletimelayer (in-range @how-many-layers)]{
   {
     int layer = @compiletimelayer;

--- a/mode-lambda/backend/gl/util.rkt
+++ b/mode-lambda/backend/gl/util.rkt
@@ -321,7 +321,7 @@
   (define (delayed-render static-arg ...)
     (define draw #f)
     (define last-glctx #f)
-    (λ (dyn-arg ...)
+    (λ (dyn-arg ... #:r (r 0) #:g (g 0) #:b (b 0))
       (λ (w h dc)
         (local-require racket/class)
         (define glctx (send dc get-gl-context))
@@ -335,7 +335,7 @@
                 (unless draw
                   (set! last-glctx glctx)
                   (set! draw (make-real-render static-arg ... init-arg ...)))
-                (draw w h dyn-arg ...)
+                (draw w h dyn-arg ... r g b)
                 (send glctx swap-buffers)))))))
 
 (define-syntax-rule (print-ms-time label e)

--- a/mode-lambda/backend/gl/util.rkt
+++ b/mode-lambda/backend/gl/util.rkt
@@ -321,7 +321,7 @@
   (define (delayed-render static-arg ...)
     (define draw #f)
     (define last-glctx #f)
-    (λ (dyn-arg ... #:r (r 0) #:g (g 0) #:b (b 0))
+    (λ (dyn-arg ... #:r [r 0] #:g [g 0] #:b [b 0])
       (λ (w h dc)
         (local-require racket/class)
         (define glctx (send dc get-gl-context))

--- a/mode-lambda/backend/software.rkt
+++ b/mode-lambda/backend/software.rkt
@@ -447,7 +447,7 @@
 (define gui-mode 'draw)
 (define (stage-draw/dc csd width height how-many-layers)
   (define render (stage-render csd width height how-many-layers))
-  (λ (layer-config static-st dynamic-st #:r (r 0) #:g (g 0) #:b (b 0))
+  (λ (layer-config static-st dynamic-st #:r [r 0] #:g [g 0] #:b [b 0])
     (define sprite-tree (cons static-st dynamic-st))
     (define bs (render layer-config sprite-tree r g b))
     (define bm (argb-bytes->bitmap width height bs))

--- a/mode-lambda/backend/software.rkt
+++ b/mode-lambda/backend/software.rkt
@@ -150,7 +150,7 @@
   (define X (3vec-zero))
   (define Y (3vec-zero))
   (define Z (3vec-zero))
-  (lambda (layer-config sprite-tree)
+  (lambda (layer-config sprite-tree r g b)
     ;; The layer multiplications can be used for all vertices and we
     ;; could just upload the correct matrices, one per layer (M2) in
     ;; this code.
@@ -331,7 +331,11 @@
     ;; Clear the screen
     (for ([root-bs (in-vector root-bs-v)])
       (bytes-fill! root-bs 0))
-    (bytes-fill! combined-bs 0)
+    
+    (define BackgroundColor (bytes 0 r g b))
+    (for ((i (in-range 0 (bytes-length combined-bs) 4)))
+      (bytes-copy! combined-bs i BackgroundColor))
+    
     ;; Fill the screen
     (define (fill! layer x y na nr ng nb)
       (define root-bs (vector-ref root-bs-v layer))
@@ -443,9 +447,9 @@
 (define gui-mode 'draw)
 (define (stage-draw/dc csd width height how-many-layers)
   (define render (stage-render csd width height how-many-layers))
-  (λ (layer-config static-st dynamic-st)
+  (λ (layer-config static-st dynamic-st #:r (r 0) #:g (g 0) #:b (b 0))
     (define sprite-tree (cons static-st dynamic-st))
-    (define bs (render layer-config sprite-tree))
+    (define bs (render layer-config sprite-tree r g b))
     (define bm (argb-bytes->bitmap width height bs))
     (when (software-bitmap-path)
       (save-bitmap! bm (software-bitmap-path)))

--- a/mode-lambda/core.rkt
+++ b/mode-lambda/core.rkt
@@ -84,7 +84,8 @@
   (vectorof (or/c false/c layer-data?)))
 
 (define-syntax-rule (backend/c (addl-input ...) output)
-  (-> layer-vector/c tree/c tree/c addl-input ... output))
+  (->* (layer-vector/c tree/c tree/c addl-input ...)
+       (#:r byte? #:g byte? #:b byte?) output))
 
 (define draw!/c
   (backend/c () void?))

--- a/mode-lambda/scribblings/backend-gl.scrbl
+++ b/mode-lambda/scribblings/backend-gl.scrbl
@@ -20,15 +20,19 @@ pretty fast, but kind of complicated.
                (->i ([layer-config (vectorof layer-data?)]
                      [static-st any/c]
                      [dynamic-st any/c])
+                    (#:r [r byte?]
+                     #:g [g byte?]
+                     #:b [b byte?])
                     (->i ([draw-width exact-nonnegative-integer?]
                           [draw-height exact-nonnegative-integer?]
                           [dc any/c])
                          any)))]{
 
 Prepares a function that accepts rendering states and returns a
-function that draws that rendering state. @racket[layers] must be less
-than or equal to @litchar{GL_MAX_ARRAY_TEXTURE_LAYERS}, which is at
-least @racket[256], but typically @racket[2048].}
+function that draws that rendering state, with optionally specified
+background color. @racket[layers] must be less than or equal to
+@litchar{GL_MAX_ARRAY_TEXTURE_LAYERS}, which is at least @racket[256],
+but typically @racket[2048].}
 
 @defthing[gui-mode symbol?]{
 

--- a/mode-lambda/scribblings/backend-software.scrbl
+++ b/mode-lambda/scribblings/backend-software.scrbl
@@ -20,6 +20,9 @@ very slow, and a little complicated, but easier to test than
                (->i ([layer-config (vectorof layer-data?)]
                      [static-st any/c]
                      [dynamic-st any/c])
+                    (#:r [r byte?]
+                     #:g [g byte?]
+                     #:b [b byte?])
                     (->i ([draw-width exact-nonnegative-integer?]
                           [draw-height exact-nonnegative-integer?]
                           [dc any/c])


### PR DESCRIPTION
Let me know if you'd rather specify r/g/b by flonum instead of by byte.  Thanks!