### PR TITLE
Add missing dependency

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -4,6 +4,7 @@
                "scheme-lib"
                "web-server-lib"
                "lux"
+               "reprovide-lang-lib"
                "base" "srfi-lite-lib" "draw-lib" "opengl" "htdp-lib" "pict-lib" "draw-lib"))
 (define build-deps '("draw-doc"
                      "racket-doc"


### PR DESCRIPTION
The package server build is currently failing due to a missing dependency on `reprovide-lang-lib`.